### PR TITLE
Installing Code Coverage (CodeCov)

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,6 @@
+[report]
+omit =
+    data/*
+    data_resized/*
+    tools/*
+    label_persons/*

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ tools/chromedriver
 
 geckodriver.log
 .DS_Store
+.coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,7 @@ install:
   - pip install -r test-requirements.txt
 script:
   - flake8 .
-  - pytest ./tests/test_*.py
+  - pytest ./tests/test_*.py --cov=./
+
+after_success:
+  - codecov

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,5 @@
 flake8
 rfc6266==0.0.4
+pytest==3.4.0
+pytest-cov==2.5.1
+codecov


### PR DESCRIPTION
Fixes #74 

Installing Code Coverage, using CodeCov. 
@marco-c Once this application is integrated with the repo we can get the reports in PRs.