### PR TITLE
Use scrollIntoView for all elements

### DIFF
--- a/collect.py
+++ b/collect.py
@@ -143,6 +143,8 @@ def do_something(driver, elem_attributes=None):
     if elem is None:
         return None
 
+    driver.execute_script("arguments[0].scrollIntoView();", elem)
+
     if elem.tag_name in ['button', 'a']:
         elem.click()
     elif elem.tag_name == 'input':


### PR DESCRIPTION
Before any interaction with the element, scroll it into view
Although `.click()` handles the scrolling element into view for buttons, having a more general step would help in some special inputs e.g. Calender, Color etc. 
So we can scroll to them and set the inputs directly in `.value` for these.
Also scrollIntoView is more consistent on Firefox and Chrome and produces similar screenshots.