### PR TITLE
Added test case for 'balance' function in utils.py for issue #69

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ For the unsupervised training, we are using a related problem for which we alrea
 
 **Python 3** is required.
 
+- Install [Git Large File Storage](https://git-lfs.github.com/), either manually or through a package like `git-lfs` if available on your system.
+- Clone the repository with submodules: `git clone --recurse-submodules git@github.com:marco-c/autowebcompat.git`
 - Install the dependencies in requirements.txt: `pip install -r requirements.txt`.
 - Install the dependencies in test-requirements.txt: `pip install -r test-requirements.txt`.
 - Run the **pretrain.py / train.py** script to train the neural network.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -71,7 +71,6 @@ def test_balance():
     assert(('data2', 1) == next(balanced_data))
     assert(('data4', 0) == next(balanced_data))
     assert(('data6', 1) == next(balanced_data))
-    assert(('data5', 0) == next(balanced_data))
 
     with pytest.raises(StopIteration):
         next(balanced_data)
@@ -89,9 +88,9 @@ def test_balance_unbalanced_data():
 
     assert(('data1', 1) == next(balanced_data))
     assert(('data4', 0) == next(balanced_data))
-    assert(('data2', 1) == next(balanced_data))
-    assert(('data5', 0) == next(balanced_data))
     assert(('data3', 1) == next(balanced_data))
+    assert(('data5', 0) == next(balanced_data))
+    assert(('data2', 1) == next(balanced_data))
 
     with pytest.raises(StopIteration):
         next(balanced_data)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -75,3 +75,23 @@ def test_balance():
 
     with pytest.raises(StopIteration):
         next(balanced_data)
+
+
+def test_balance_unbalanced_data():
+    unbalanced_tuples = [
+        ("data1", 1),
+        ("data2", 1),
+        ("data3", 1),
+        ("data4", 0),
+        ("data5", 0)]
+
+    balanced_data = utils.balance(unbalanced_tuples)
+
+    assert(('data1', 1) == next(balanced_data))
+    assert(('data4', 0) == next(balanced_data))
+    assert(('data3', 1) == next(balanced_data))
+    assert(('data5', 0) == next(balanced_data))
+    assert(('data2', 1) == next(balanced_data))
+
+    with pytest.raises(StopIteration):
+        next(balanced_data)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -89,9 +89,9 @@ def test_balance_unbalanced_data():
 
     assert(('data1', 1) == next(balanced_data))
     assert(('data4', 0) == next(balanced_data))
-    assert(('data3', 1) == next(balanced_data))
-    assert(('data5', 0) == next(balanced_data))
     assert(('data2', 1) == next(balanced_data))
+    assert(('data5', 0) == next(balanced_data))
+    assert(('data3', 1) == next(balanced_data))
 
     with pytest.raises(StopIteration):
         next(balanced_data)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,6 +3,7 @@ from tempfile import TemporaryDirectory
 import numpy as np
 from PIL import Image
 from autowebcompat import utils
+import pytest
 
 
 def test_get_bugs():
@@ -56,23 +57,21 @@ def test_write_labels():
 
 def test_balance():
     unbalanced_tuples = [
-        ("data", 1),
-        ("data", 1),
-        ("data", 0),
-        ("data", 0),
-        ("data", 0),
-        ("data", 1)]
+        ("data1", 1),
+        ("data2", 1),
+        ("data3", 0),
+        ("data4", 0),
+        ("data5", 0),
+        ("data6", 1)]
 
     balanced_data = utils.balance(unbalanced_tuples)
-    num_iterations = 0
 
-    try:
-        expected_label = 1
-        while True:
-            element = next(balanced_data)
-            assert(element[1] == expected_label)
-            num_iterations += 1
-            expected_label = (expected_label + 1) % 2
-    except StopIteration:
-        assert(num_iterations == 6)
-        pass
+    assert(('data1', 1) == next(balanced_data))
+    assert(('data3', 0) == next(balanced_data))
+    assert(('data2', 1) == next(balanced_data))
+    assert(('data4', 0) == next(balanced_data))
+    assert(('data6', 1) == next(balanced_data))
+    assert(('data5', 0) == next(balanced_data))
+
+    with pytest.raises(StopIteration):
+        next(balanced_data)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -64,13 +64,15 @@ def test_balance():
         ("data", 1)]
 
     balanced_data = utils.balance(unbalanced_tuples)
+    num_iterations = 0
 
     try:
         expected_label = 1
         while True:
             element = next(balanced_data)
             assert(element[1] == expected_label)
+            num_iterations += 1
             expected_label = (expected_label + 1) % 2
     except StopIteration:
-        del(balanced_data)
+        assert(num_iterations == 6)
         pass

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -52,3 +52,24 @@ def test_write_labels():
     file_path = d.name + "/test.csv"
     utils.write_labels(label, file_name=file_path)
     assert(os.path.exists(file_path))
+
+def test_balance():
+    unbalanced_tuples = [
+        ("data", 1),
+        ("data", 1),
+        ("data", 0),
+        ("data", 0),
+        ("data", 0),
+        ("data", 1)]
+
+    balanced_data = utils.balance(unbalanced_tuples)
+
+    try:
+        expected_label = 1
+        while True:
+            element = next(balanced_data)
+            assert(element[1] == expected_label)
+            expected_label = (expected_label + 1) % 2
+    except StopIteration:
+        del(balanced_data)
+        pass

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -53,6 +53,7 @@ def test_write_labels():
     utils.write_labels(label, file_name=file_path)
     assert(os.path.exists(file_path))
 
+
 def test_balance():
     unbalanced_tuples = [
         ("data", 1),


### PR DESCRIPTION
Fixes #69.

As per my current understanding, the 'balance' function accepts a sequence of items (each item has label at index 1) and yields data items with alternating labels. The first label to be returned is the label that occurs first in the original sequence