### PR TITLE
Add draw_boundary_box to select area where incompatibility lies.

### DIFF
--- a/autowebcompat/utils.py
+++ b/autowebcompat/utils.py
@@ -198,20 +198,15 @@ def write_labels(labels, file_name='labels.csv'):
             writer.writerow([key, values])
 
 
-def read_boundary_boxes(file_name):
+def read_bounding_boxes(file_name):
     try:
         with open(file_name, 'r') as f:
-            next(f)
-            reader = csv.reader(f)
-            boundary_boxes = {row[0]: ast.literal_eval(row[1]) for row in reader}
+            bounding_boxes = json.load(f)
     except FileNotFoundError:
-        boundary_boxes = {}
-    return boundary_boxes
+        bounding_boxes = {}
+    return bounding_boxes
 
 
-def write_boundary_boxes(boundary_boxes, file_name):
+def write_bounding_boxes(bounding_boxes, file_name):
     with open(file_name, 'w') as f:
-        writer = csv.writer(f, delimiter=',')
-        writer.writerow(["Image Name", "Boundary Boxes (top_left_x,top_left_y,bottom_right_x,bottom_right_y)"])
-        for key, values in boundary_boxes.items():
-            writer.writerow([key, values])
+        print(json.dumps(bounding_boxes), file=f)

--- a/autowebcompat/utils.py
+++ b/autowebcompat/utils.py
@@ -1,3 +1,4 @@
+import ast
 import json
 import os
 import random
@@ -194,4 +195,23 @@ def write_labels(labels, file_name='labels.csv'):
         writer = csv.writer(f, delimiter=',')
         writer.writerow(["Image Name", "Label"])
         for key, values in labels.items():
+            writer.writerow([key, values])
+
+
+def read_boundary_boxes(file_name):
+    try:
+        with open(file_name, 'r') as f:
+            next(f)
+            reader = csv.reader(f)
+            boundary_boxes = {row[0]: ast.literal_eval(row[1]) for row in reader}
+    except FileNotFoundError:
+        boundary_boxes = {}
+    return boundary_boxes
+
+
+def write_boundary_boxes(boundary_boxes, file_name):
+    with open(file_name, 'w') as f:
+        writer = csv.writer(f, delimiter=',')
+        writer.writerow(["Image Name", "Boundary Boxes (top_left_x,top_left_y,bottom_right_x,bottom_right_y)"])
+        for key, values in boundary_boxes.items():
             writer.writerow([key, values])

--- a/generate_labels.py
+++ b/generate_labels.py
@@ -11,6 +11,8 @@ ydn_map = {'y': 0, 'd': 1, 'n': 2}
 ydn_reverse_map = {0: 'y', 1: 'd', 2: 'n'}
 
 for file_name in all_file_names:
+    if 'boundary_box' in file_name:
+        continue
     labels = utils.read_labels(labels_directory + file_name)
     for key, value in labels.items():
         if key not in labels_voted.keys():

--- a/label.py
+++ b/label.py
@@ -1,6 +1,8 @@
 import argparse
 from PIL import ImageTk, Image
 from tkinter import Tk, Label
+import cv2
+import numpy as np
 
 
 from autowebcompat import utils
@@ -11,16 +13,52 @@ parser = argparse.ArgumentParser()
 parser.add_argument("file_name", action="store")
 args = parser.parse_args()
 
-labels = utils.read_labels(labels_directory + args.file_name)
+labels = utils.read_labels(labels_directory + args.file_name + ".csv")
+boundary_boxes = utils.read_boundary_boxes(labels_directory + args.file_name + "_boundary_box.csv")
 
 images_to_show = [i for i in utils.get_images() if i not in labels]
 current_image = None
+drawing = False
 
 root = Tk()
 panel1 = Label(root)
 panel1.pack(side="left", padx=10)
 panel2 = Label(root)
 panel2.pack(side="left", padx=10)
+
+
+def draw_boundary_box(event, mouse_x, mouse_y, flags, param):
+    global start_x, start_y, drawing, end_x, end_y
+    [drawing_area, boxes] = param
+
+    if event == cv2.EVENT_LBUTTONDOWN:
+        drawing = True
+        start_x, start_y = mouse_x, mouse_y
+        end_x, end_y = mouse_x, mouse_y
+    elif event == cv2.EVENT_MOUSEMOVE:
+        if drawing is True:
+            box_start_x, box_start_y = start_x, start_y
+            box_end_x, box_end_y = end_x, end_y
+            if box_start_x > box_end_x:
+                box_start_x, box_end_x = box_end_x, box_start_x
+            if box_start_y > box_end_y:
+                box_start_y, box_end_y = box_end_y, box_start_y
+            box_start_x = max(0, box_start_x)
+            box_start_y = max(0, box_start_y)
+            box_end_x = min(drawing_area.shape[1], box_end_x)
+            box_end_y = min(drawing_area.shape[0], box_end_y)
+            drawing_area[box_start_y:box_end_y + 1, box_start_x:box_end_x + 1, 0:3] = 0
+            end_x = max(mouse_x, 0)
+            end_y = max(mouse_y, 0)
+            cv2.rectangle(drawing_area, (start_x, start_y), (end_x, end_y), (0, 255, 0), -1)
+    elif event == cv2.EVENT_LBUTTONUP:
+        drawing = False
+        start_x = max(0, start_x)
+        start_y = max(0, start_y)
+        end_x = min(drawing_area.shape[1], end_x)
+        end_y = min(drawing_area.shape[0], end_y)
+        cv2.rectangle(drawing_area, (start_x, start_y), (end_x, end_y), (0, 255, 0), -1)
+        boxes.append([min(start_x, end_x), min(start_y, end_y), max(start_x, end_x), max(start_y, end_y)])
 
 
 def get_new_image():
@@ -56,6 +94,47 @@ def callback_n(e):
     get_new_image()
 
 
+# The images are not the same and you want to mark the boundary box.
+def callback_m(e):
+    labels[current_image] = 'n'
+    cv2.namedWindow('firefox')
+    cv2.namedWindow('chrome')
+    firefox_ss = cv2.imread("data/%s_firefox.png" % current_image)
+    chrome_ss = cv2.imread("data/%s_chrome.png" % current_image)
+    drawing_area_firefox = np.zeros((firefox_ss.shape), np.uint8)
+    drawing_area_chrome = np.zeros((chrome_ss.shape), np.uint8)
+    boxes_firefox = []
+    boxes_chrome = []
+    cv2.setMouseCallback('firefox', draw_boundary_box, [drawing_area_firefox, boxes_firefox])
+    cv2.setMouseCallback('chrome', draw_boundary_box, [drawing_area_chrome, boxes_chrome])
+    while True:
+        firefox_window = cv2.addWeighted(drawing_area_firefox, 0.5, firefox_ss, 0.5, 0)
+        chrome_window = cv2.addWeighted(drawing_area_chrome, 0.5, chrome_ss, 0.5, 0)
+        cv2.imshow('firefox', firefox_window)
+        cv2.imshow('chrome', chrome_window)
+        cv2.moveWindow('firefox', 20, 0)
+        cv2.moveWindow('chrome', 20 + firefox_window.shape[1], 0)
+        k = cv2.waitKey(1) & 0xFF
+        # <Escape> quits marking area without saving
+        if k == 27:
+            break
+        # 'r' resets the present selection of boundary boxes
+        elif k == 114:
+            drawing_area_firefox = np.zeros((firefox_ss.shape), np.uint8)
+            drawing_area_chrome = np.zeros((chrome_ss.shape), np.uint8)
+            boxes_chrome = []
+            boxes_firefox = []
+            cv2.setMouseCallback('firefox', draw_boundary_box, [drawing_area_firefox, boxes_firefox])
+            cv2.setMouseCallback('chrome', draw_boundary_box, [drawing_area_chrome, boxes_chrome])
+        # <Return> saves the current marking and moves to next image
+        elif k == 13:
+            boundary_boxes[current_image + '_firefox'] = boxes_firefox
+            boundary_boxes[current_image + '_chrome'] = boxes_chrome
+            break
+    cv2.destroyAllWindows()
+    get_new_image()
+
+
 def callback_skip(e):
     get_new_image()
 
@@ -68,9 +147,11 @@ get_new_image()
 root.bind("y", callback_y)
 root.bind("d", callback_d)
 root.bind("n", callback_n)
+root.bind("m", callback_m)
 root.bind("<Return>", callback_skip)
 root.bind("<Escape>", close)
 root.mainloop()
 
 # Store results.
-utils.write_labels(labels, labels_directory + args.file_name)
+utils.write_boundary_boxes(boundary_boxes, labels_directory + args.file_name + "_boundary_box.csv")
+utils.write_labels(labels, labels_directory + args.file_name + ".csv")

--- a/label.py
+++ b/label.py
@@ -1,8 +1,8 @@
 import argparse
-from PIL import ImageTk, Image
-from tkinter import Tk, Label
 import cv2
 import numpy as np
+from PIL import ImageTk, Image
+from tkinter import Tk, Label
 
 
 from autowebcompat import utils

--- a/label.py
+++ b/label.py
@@ -19,7 +19,7 @@ drawing = False
 shifting = False
 changing_shape = False
 box_to_change = {}
-all_boxes = []
+all_boxes = {}
 key_map = {"Escape": 27, "r": 114, "Enter": 13, "Space": 32, "y": 121, "n": 110, "d": 100}
 cv2.namedWindow('firefox')
 cv2.namedWindow('chrome')
@@ -256,7 +256,7 @@ def get_new_image():
         elif k == key_map["r"]:
             drawing_area_firefox = reset_bounding_boxes(firefox_screenshot.shape)
             drawing_area_chrome = reset_bounding_boxes(chrome_screenshot.shape)
-            all_boxes, boxes_chrome, boxes_firefox = [], [], []
+            all_boxes, boxes_firefox, boxes_chrome = {'n': [], 'd': []}, {'n': [], 'd': []}, {'n': [], 'd': []}
             cv2.setMouseCallback('firefox', draw_bounding_boxes, [drawing_area_firefox, drawing_area_chrome, boxes_firefox])
             cv2.setMouseCallback('chrome', draw_bounding_boxes, [drawing_area_chrome, drawing_area_firefox, boxes_chrome])
         # <Return> saves the current marking and moves to next image

--- a/label.py
+++ b/label.py
@@ -16,63 +16,179 @@ bounding_boxes = utils.read_bounding_boxes(labels_directory + args.file_name + "
 
 images_to_show = [i for i in utils.get_images() if i not in labels]
 drawing = False
-key_map = {"Escape": 27, "r": 114, "Enter": 13, "y": 121, "n": 110, "d": 100}
+shifting = False
+changing_shape = False
+box_to_shift = []
+key_map = {"Escape": 27, "r": 114, "Enter": 13, "Space": 32, "y": 121, "n": 110, "d": 100}
 cv2.namedWindow('firefox')
 cv2.namedWindow('chrome')
 cv2.namedWindow('firefox_chrome_overlay')
 
 
-def reset_bounding_boxes(drawing_area_shape_firefox, drawing_area_shape_chrome):
-    return (np.zeros(drawing_area_shape_firefox, np.uint8), np.zeros(drawing_area_shape_chrome, np.uint8))
+def reset_bounding_boxes(drawing_area_shape):
+    return np.zeros(drawing_area_shape, np.uint8)
 
 
-def draw_bounding_box(event, mouse_x, mouse_y, flags, param):
-    global start_x, start_y, drawing, end_x, end_y
+def top_left_bottom_right_box(start_x, start_y, end_x, end_y):
+    box_start_x, box_start_y = start_x, start_y
+    box_end_x, box_end_y = end_x, end_y
+    box_start_x, box_end_x = min(box_start_x, box_end_x), max(box_start_x, box_end_x)
+    box_start_y, box_end_y = min(box_start_y, box_end_y), max(box_start_y, box_end_y)
+    return box_start_x, box_start_y, box_end_x, box_end_y
+
+
+def fit_bounding_box(start_x, start_y, end_x, end_y, x_max, y_max):
+    start_x = max(0, start_x)
+    start_y = max(0, start_y)
+    end_x = min(x_max, end_x)
+    end_y = min(y_max, end_y)
+    return [start_x, start_y, end_x, end_y]
+
+
+def check_cross_click(start_x, start_y, box):
+    if start_x >= box[2] - 15 and start_x <= box[2] and start_y >= box[1] and start_y <= box[1] + 15:
+        return True
+    return False
+
+
+def check_plus_click(start_x, start_y, box):
+    center_x = (box[0] + box[2]) // 2
+    center_y = (box[1] + box[3]) // 2
+    if start_x >= center_x - 10 and start_x <= center_x + 10 and start_y >= center_y - 10 and start_y <= center_y + 10:
+        return True
+    return False
+
+
+def check_arrow_click(start_x, start_y, box):
+    if start_x >= box[2] - 10 and start_x <= box[2] and start_y >= box[3] - 10 and start_y <= box[3]:
+        return True
+    return False
+
+
+def shift_bounding_box(box_to_shift, start_x, start_y, end_x, end_y):
+    box_start_x = box_to_shift[0] + (end_x - start_x)
+    box_start_y = box_to_shift[1] + (end_y - start_y)
+    box_end_x = box_to_shift[2] + (end_x - start_x)
+    box_end_y = box_to_shift[3] + (end_y - start_y)
+    (box_start_x, box_start_y, box_end_x, box_end_y) = top_left_bottom_right_box(box_start_x, box_start_y, box_end_x, box_end_y)
+    return (box_start_x, box_start_y, box_end_x, box_end_y)
+
+
+def change_bounding_box(box_to_shift, start_x, start_y, end_x, end_y):
+    (box_start_x, box_start_y, box_end_x, box_end_y) = top_left_bottom_right_box(box_to_shift[0], box_to_shift[1], end_x, end_y)
+    return (box_start_x, box_start_y, box_end_x, box_end_y)
+
+
+def create_bounding_box(drawing_area, start_x, start_y, end_x, end_y):
+    cv2.rectangle(drawing_area, (start_x, start_y), (end_x, end_y), (0, 255, 0), -1)
+
+
+def create_cross(drawing_area, start_x, start_y, end_x, end_y):
+    cv2.line(drawing_area, (end_x - 2, start_y + 2), (end_x - 12, start_y + 12), (0, 0, 255), 2)
+    cv2.line(drawing_area, (end_x - 12, start_y + 2), (end_x - 2, start_y + 12), (0, 0, 255), 2)
+
+
+def create_plus(drawing_area, start_x, start_y, end_x, end_y):
+    center_x = (start_x + end_x) // 2
+    center_y = (start_y + end_y) // 2
+    cv2.arrowedLine(drawing_area, (center_x, center_y - 10), (center_x, center_y + 10), (255, 0, 0), 2, tipLength=0.2)
+    cv2.arrowedLine(drawing_area, (center_x - 10, center_y), (center_x + 10, center_y), (255, 0, 0), 2, tipLength=0.2)
+    cv2.arrowedLine(drawing_area, (center_x, center_y + 10), (center_x, center_y - 10), (255, 0, 0), 2, tipLength=0.2)
+    cv2.arrowedLine(drawing_area, (center_x + 10, center_y), (center_x - 10, center_y), (255, 0, 0), 2, tipLength=0.2)
+
+
+def create_change_shape(drawing_area, start_x, start_y, end_x, end_y):
+    cv2.arrowedLine(drawing_area, (end_x - 12, end_y - 12), (end_x - 2, end_y - 2), (255, 0, 0), 2, tipLength=0.3)
+    cv2.arrowedLine(drawing_area, (end_x - 2, end_y - 2), (end_x - 12, end_y - 12), (255, 0, 0), 2, tipLength=0.3)
+
+
+def draw_bounding_boxes(event, mouse_x, mouse_y, flags, param):
+    global start_x, start_y, drawing, end_x, end_y, shifting, box_to_shift, changing_shape
     [drawing_area, boxes] = param
 
+    for box in boxes:
+        create_bounding_box(drawing_area, box[0], box[1], box[2], box[3])
+        create_cross(drawing_area, box[0], box[1], box[2], box[3])
+        create_plus(drawing_area, box[0], box[1], box[2], box[3])
+        create_change_shape(drawing_area, box[0], box[1], box[2], box[3])
+
     if event == cv2.EVENT_LBUTTONDOWN:
-        drawing = True
         start_x, start_y = mouse_x, mouse_y
         end_x, end_y = mouse_x, mouse_y
+        for box in boxes:
+            if check_cross_click(start_x, start_y, box):
+                drawing_area[box[1]: box[3] + 1, box[0]: box[2] + 1, 0:3] = 0
+                boxes.remove(box)
+                return
+            if check_plus_click(start_x, start_y, box):
+                drawing_area[box[1]: box[3] + 1, box[0]: box[2] + 1, 0:3] = 0
+                shifting = True
+                box_to_shift = box[:]
+                boxes.remove(box)
+                return
+            if check_arrow_click(start_x, start_y, box):
+                drawing_area[box[1]: box[3] + 1, box[0]: box[2] + 1, 0:3] = 0
+                changing_shape = True
+                box_to_shift = box[:]
+                boxes.remove(box)
+                return
+        drawing = True
     elif event == cv2.EVENT_MOUSEMOVE:
         if drawing is True:
-            box_start_x, box_start_y = start_x, start_y
-            box_end_x, box_end_y = end_x, end_y
-            if box_start_x > box_end_x:
-                box_start_x, box_end_x = box_end_x, box_start_x
-            if box_start_y > box_end_y:
-                box_start_y, box_end_y = box_end_y, box_start_y
-            box_start_x = max(0, box_start_x)
-            box_start_y = max(0, box_start_y)
-            box_end_x = min(drawing_area.shape[1], box_end_x)
-            box_end_y = min(drawing_area.shape[0], box_end_y)
+            (box_start_x, box_start_y, box_end_x, box_end_y) = top_left_bottom_right_box(start_x, start_y, end_x, end_y)
             drawing_area[box_start_y:box_end_y + 1, box_start_x:box_end_x + 1, 0:3] = 0
-            end_x = max(mouse_x, 0)
-            end_y = max(mouse_y, 0)
-            cv2.rectangle(drawing_area, (start_x, start_y), (end_x, end_y), (0, 255, 0), -1)
+            end_x, end_y = mouse_x, mouse_y
+            (box_start_x, box_start_y, box_end_x, box_end_y) = fit_bounding_box(start_x, start_y, end_x, end_y, drawing_area.shape[1], drawing_area.shape[0])
+            create_bounding_box(drawing_area, box_start_x, box_start_y, box_end_x, box_end_y)
+        elif shifting is True:
+            (box_start_x, box_start_y, box_end_x, box_end_y) = shift_bounding_box(box_to_shift, start_x, start_y, end_x, end_y)
+            (box_start_x, box_start_y, box_end_x, box_end_y) = fit_bounding_box(box_start_x, box_start_y, box_end_x, box_end_y, drawing_area.shape[1], drawing_area.shape[0])
+            drawing_area[box_start_y:box_end_y + 1, box_start_x:box_end_x + 1, 0:3] = 0
+            end_x, end_y = mouse_x, mouse_y
+
+            (box_start_x, box_start_y, box_end_x, box_end_y) = shift_bounding_box(box_to_shift, start_x, start_y, end_x, end_y)
+            (box_start_x, box_start_y, box_end_x, box_end_y) = fit_bounding_box(box_start_x, box_start_y, box_end_x, box_end_y, drawing_area.shape[1], drawing_area.shape[0])
+            create_bounding_box(drawing_area, box_start_x, box_start_y, box_end_x, box_end_y)
+        elif changing_shape is True:
+            (box_start_x, box_start_y, box_end_x, box_end_y) = change_bounding_box(box_to_shift, start_x, start_y, end_x, end_y)
+            (box_start_x, box_start_y, box_end_x, box_end_y) = fit_bounding_box(box_start_x, box_start_y, box_end_x, box_end_y, drawing_area.shape[1], drawing_area.shape[0])
+            drawing_area[box_start_y:box_end_y + 1, box_start_x:box_end_x + 1, 0:3] = 0
+            end_x, end_y = mouse_x, mouse_y
+            (box_start_x, box_start_y, box_end_x, box_end_y) = change_bounding_box(box_to_shift, start_x, start_y, end_x, end_y)
+            (box_start_x, box_start_y, box_end_x, box_end_y) = fit_bounding_box(box_start_x, box_start_y, box_end_x, box_end_y, drawing_area.shape[1], drawing_area.shape[0])
+            create_bounding_box(drawing_area, box_start_x, box_start_y, box_end_x, box_end_y)
+
     elif event == cv2.EVENT_LBUTTONUP:
-        drawing = False
-        start_x = max(0, start_x)
-        start_y = max(0, start_y)
-        end_x = min(drawing_area.shape[1], end_x)
-        end_y = min(drawing_area.shape[0], end_y)
-        cv2.rectangle(drawing_area, (start_x, start_y), (end_x, end_y), (0, 255, 0), -1)
-        boxes.append([min(start_x, end_x), min(start_y, end_y), max(start_x, end_x), max(start_y, end_y)])
+        if shifting is True:
+            shifting = False
+            (box_start_x, box_start_y, box_end_x, box_end_y) = shift_bounding_box(box_to_shift, start_x, start_y, end_x, end_y)
+            (box_start_x, box_start_y, box_end_x, box_end_y) = fit_bounding_box(box_start_x, box_start_y, box_end_x, box_end_y, drawing_area.shape[1], drawing_area.shape[0])
+            boxes.append([box_start_x, box_start_y, box_end_x, box_end_y])
+        elif drawing is True:
+            drawing = False
+            (start_x, start_y, end_x, end_y) = top_left_bottom_right_box(start_x, start_y, end_x, end_y)
+            (box_start_x, box_start_y, box_end_x, box_end_y) = fit_bounding_box(start_x, start_y, end_x, end_y, drawing_area.shape[1], drawing_area.shape[0])
+            boxes.append([box_start_x, box_start_y, box_end_x, box_end_y])
+        elif changing_shape is True:
+            changing_shape = False
+            (box_start_x, box_start_y, box_end_x, box_end_y) = change_bounding_box(box_to_shift, start_x, start_y, end_x, end_y)
+            (box_start_x, box_start_y, box_end_x, box_end_y) = fit_bounding_box(box_start_x, box_start_y, box_end_x, box_end_y, drawing_area.shape[1], drawing_area.shape[0])
+            boxes.append([box_start_x, box_start_y, box_end_x, box_end_y])
 
 
 # The images are not the same and you want to mark the bounding box.
 def get_new_image():
-    if len(images_to_show) == 0:
-        cv2.destroyAllWindows()
-        return
     current_image = images_to_show.pop()
     print("Reading %s" % current_image)
     firefox_screenshot = cv2.imread("data/%s_firefox.png" % current_image)
     chrome_screenshot = cv2.imread("data/%s_chrome.png" % current_image)
-    drawing_area_firefox, drawing_area_chrome = reset_bounding_boxes(firefox_screenshot.shape, chrome_screenshot.shape)
+    if firefox_screenshot.shape != chrome_screenshot.shape:
+        return 0
+    drawing_area_firefox = reset_bounding_boxes(firefox_screenshot.shape)
+    drawing_area_chrome = reset_bounding_boxes(chrome_screenshot.shape)
     boxes_firefox, boxes_chrome = [], []
-    cv2.setMouseCallback('firefox', draw_bounding_box, [drawing_area_firefox, boxes_firefox])
-    cv2.setMouseCallback('chrome', draw_bounding_box, [drawing_area_chrome, boxes_chrome])
+    cv2.setMouseCallback('firefox', draw_bounding_boxes, [drawing_area_firefox, boxes_firefox])
+    cv2.setMouseCallback('chrome', draw_bounding_boxes, [drawing_area_chrome, boxes_chrome])
     visibility = 1
     while True:
         firefox_window = cv2.addWeighted(drawing_area_firefox, 1 - visibility, firefox_screenshot, visibility, 0)
@@ -88,23 +204,26 @@ def get_new_image():
         # <Escape> quits marking area without saving
         if k == key_map["Escape"]:
             cv2.destroyAllWindows()
-            return
+            return 1
         # 'r' resets the present selection of bounding boxes
         elif k == key_map["r"]:
-            drawing_area_firefox, drawing_area_chrome = reset_bounding_boxes(firefox_screenshot.shape, chrome_screenshot.shape)
+            drawing_area_firefox = reset_bounding_boxes(firefox_screenshot.shape)
+            drawing_area_chrome = reset_bounding_boxes(chrome_screenshot.shape)
             boxes_chrome, boxes_firefox = [], []
-            cv2.setMouseCallback('firefox', draw_bounding_box, [drawing_area_firefox, boxes_firefox])
-            cv2.setMouseCallback('chrome', draw_bounding_box, [drawing_area_chrome, boxes_chrome])
-        # <Return> saves the current marking and moves to next image or skips it if no label is assigned
+            cv2.setMouseCallback('firefox', draw_bounding_boxes, [drawing_area_firefox, boxes_firefox])
+            cv2.setMouseCallback('chrome', draw_bounding_boxes, [drawing_area_chrome, boxes_chrome])
+        # <Return> saves the current marking and moves to next image
         elif k == key_map["Enter"]:
-            if current_image not in labels.keys():
-                break
             bounding_boxes[current_image + '_firefox'] = boxes_firefox
             bounding_boxes[current_image + '_chrome'] = boxes_chrome
-            break
+            return 0
+        # <Space> skips the labeling of current image
+        elif k == key_map["Space"]:
+            if current_image not in labels.keys():
+                return 0
         elif k == key_map["y"]:
             labels[current_image] = 'y'
-            break
+            return 0
         elif k == key_map["n"]:
             labels[current_image] = 'n'
             visibility = 0.5
@@ -112,11 +231,15 @@ def get_new_image():
             labels[current_image] = 'd'
             visibility = 0.5
 
-    get_new_image()
+
+def main():
+    while len(images_to_show):
+        if get_new_image():
+            break
+    # Store results.
+    utils.write_bounding_boxes(bounding_boxes, labels_directory + args.file_name + "_bounding_box.json")
+    utils.write_labels(labels, labels_directory + args.file_name + ".csv")
 
 
-get_new_image()
-
-# Store results.
-utils.write_bounding_boxes(bounding_boxes, labels_directory + args.file_name + "_bounding_box.json")
-utils.write_labels(labels, labels_directory + args.file_name + ".csv")
+if __name__ == '__main__':
+    main()

--- a/label.py
+++ b/label.py
@@ -11,8 +11,8 @@ parser = argparse.ArgumentParser()
 parser.add_argument('file_name', action='store')
 args = parser.parse_args()
 
-labels = utils.read_labels(labels_directory + args.file_name + ".csv")
-bounding_boxes = utils.read_bounding_boxes(labels_directory + args.file_name + "_bounding_box.json")
+labels = utils.read_labels(labels_directory + args.file_name + '.csv')
+bounding_boxes = utils.read_bounding_boxes(labels_directory + args.file_name + '_bounding_box.json')
 
 images_to_show = [i for i in utils.get_images() if i not in labels]
 drawing = False
@@ -20,7 +20,7 @@ shifting = False
 changing_shape = False
 box_to_change = {}
 all_boxes = {}
-key_map = {"Escape": 27, "r": 114, "Enter": 13, "Space": 32, "y": 121, "n": 110, "d": 100}
+key_map = {'Escape': 27, 'r': 114, 'Enter': 13, 'Space': 32, 'y': 121, 'n': 110, 'd': 100}
 cv2.namedWindow('firefox')
 cv2.namedWindow('chrome')
 cv2.namedWindow('firefox_chrome_overlay')
@@ -223,9 +223,9 @@ def draw_bounding_boxes(event, mouse_x, mouse_y, flags, param):
 def get_new_image():
     global all_boxes
     current_image = images_to_show.pop()
-    print("Reading %s" % current_image)
-    firefox_screenshot = cv2.imread("data/%s_firefox.png" % current_image)
-    chrome_screenshot = cv2.imread("data/%s_chrome.png" % current_image)
+    print('Reading %s' % current_image)
+    firefox_screenshot = cv2.imread('data/%s_firefox.png' % current_image)
+    chrome_screenshot = cv2.imread('data/%s_chrome.png' % current_image)
     if firefox_screenshot.shape != chrome_screenshot.shape:
         return 0
     drawing_area_firefox = reset_bounding_boxes(firefox_screenshot.shape)
@@ -249,18 +249,18 @@ def get_new_image():
         cv2.moveWindow('firefox_chrome_overlay', 20 + firefox_window.shape[1] + chrome_window.shape[1], 0)
         k = cv2.waitKey(1) & 0xFF
         # <Escape> quits marking area without saving
-        if k == key_map["Escape"]:
+        if k == key_map['Escape']:
             cv2.destroyAllWindows()
             return 1
         # 'r' resets the present selection of bounding boxes
-        elif k == key_map["r"]:
+        elif k == key_map['r']:
             drawing_area_firefox = reset_bounding_boxes(firefox_screenshot.shape)
             drawing_area_chrome = reset_bounding_boxes(chrome_screenshot.shape)
             all_boxes, boxes_firefox, boxes_chrome = {'n': [], 'd': []}, {'n': [], 'd': []}, {'n': [], 'd': []}
             cv2.setMouseCallback('firefox', draw_bounding_boxes, [drawing_area_firefox, drawing_area_chrome, boxes_firefox])
             cv2.setMouseCallback('chrome', draw_bounding_boxes, [drawing_area_chrome, drawing_area_firefox, boxes_chrome])
         # <Return> saves the current marking and moves to next image
-        elif k == key_map["Enter"]:
+        elif k == key_map['Enter']:
             if visibility == 1:
                 visibility = 0.5
             else:
@@ -274,9 +274,9 @@ def get_new_image():
                     labels[current_image] = 'n'
                 return 0
         # <Space> skips the labeling of current image
-        elif k == key_map["Space"]:
+        elif k == key_map['Space']:
             return 0
-        elif k == key_map["y"]:
+        elif k == key_map['y']:
             bounding_boxes[current_image + '_firefox'] = boxes_firefox
             bounding_boxes[current_image + '_chrome'] = boxes_chrome
             labels[current_image] = 'y'
@@ -289,8 +289,8 @@ def main():
             break
 
     # Store results.
-    utils.write_bounding_boxes(bounding_boxes, labels_directory + args.file_name + "_bounding_box.json")
-    utils.write_labels(labels, labels_directory + args.file_name + ".csv")
+    utils.write_bounding_boxes(bounding_boxes, labels_directory + args.file_name + '_bounding_box.json')
+    utils.write_labels(labels, labels_directory + args.file_name + '.csv')
 
 
 if __name__ == '__main__':

--- a/label.py
+++ b/label.py
@@ -18,7 +18,8 @@ images_to_show = [i for i in utils.get_images() if i not in labels]
 drawing = False
 shifting = False
 changing_shape = False
-box_to_shift = []
+box_to_change = {}
+all_boxes = []
 key_map = {"Escape": 27, "r": 114, "Enter": 13, "Space": 32, "y": 121, "n": 110, "d": 100}
 cv2.namedWindow('firefox')
 cv2.namedWindow('chrome')
@@ -51,6 +52,12 @@ def check_cross_click(start_x, start_y, box):
     return False
 
 
+def check_toggle_click(start_x, start_y, box):
+    if start_x >= box[0] and start_x <= box[0] + 12 and start_y >= box[1] and start_y <= box[1] + 12:
+        return True
+    return False
+
+
 def check_plus_click(start_x, start_y, box):
     center_x = (box[0] + box[2]) // 2
     center_y = (box[1] + box[3]) // 2
@@ -65,22 +72,22 @@ def check_arrow_click(start_x, start_y, box):
     return False
 
 
-def shift_bounding_box(box_to_shift, start_x, start_y, end_x, end_y):
-    box_start_x = box_to_shift[0] + (end_x - start_x)
-    box_start_y = box_to_shift[1] + (end_y - start_y)
-    box_end_x = box_to_shift[2] + (end_x - start_x)
-    box_end_y = box_to_shift[3] + (end_y - start_y)
+def shift_bounding_box(box, start_x, start_y, end_x, end_y):
+    box_start_x = box[0] + (end_x - start_x)
+    box_start_y = box[1] + (end_y - start_y)
+    box_end_x = box[2] + (end_x - start_x)
+    box_end_y = box[3] + (end_y - start_y)
     (box_start_x, box_start_y, box_end_x, box_end_y) = top_left_bottom_right_box(box_start_x, box_start_y, box_end_x, box_end_y)
     return (box_start_x, box_start_y, box_end_x, box_end_y)
 
 
-def change_bounding_box(box_to_shift, start_x, start_y, end_x, end_y):
-    (box_start_x, box_start_y, box_end_x, box_end_y) = top_left_bottom_right_box(box_to_shift[0], box_to_shift[1], end_x, end_y)
+def change_bounding_box(box, start_x, start_y, end_x, end_y):
+    (box_start_x, box_start_y, box_end_x, box_end_y) = top_left_bottom_right_box(box[0], box[1], end_x, end_y)
     return (box_start_x, box_start_y, box_end_x, box_end_y)
 
 
-def create_bounding_box(drawing_area, start_x, start_y, end_x, end_y):
-    cv2.rectangle(drawing_area, (start_x, start_y), (end_x, end_y), (0, 255, 0), -1)
+def create_bounding_box(drawing_area, start_x, start_y, end_x, end_y, color):
+    cv2.rectangle(drawing_area, (start_x, start_y), (end_x, end_y), color, -1)
 
 
 def create_cross(drawing_area, start_x, start_y, end_x, end_y):
@@ -97,87 +104,124 @@ def create_plus(drawing_area, start_x, start_y, end_x, end_y):
     cv2.arrowedLine(drawing_area, (center_x + 10, center_y), (center_x - 10, center_y), (255, 0, 0), 2, tipLength=0.2)
 
 
+def create_toggle_nd(drawing_area, start_x, start_y, end_x, end_y):
+    cv2.line(drawing_area, (start_x + 2, start_y + 2), (start_x + 12, start_y + 2), (0, 0, 255), 2)
+    cv2.line(drawing_area, (start_x + 7, start_y + 2), (start_x + 7, start_y + 12), (0, 0, 255), 2)
+
+
 def create_change_shape(drawing_area, start_x, start_y, end_x, end_y):
     cv2.arrowedLine(drawing_area, (end_x - 12, end_y - 12), (end_x - 2, end_y - 2), (255, 0, 0), 2, tipLength=0.3)
     cv2.arrowedLine(drawing_area, (end_x - 2, end_y - 2), (end_x - 12, end_y - 12), (255, 0, 0), 2, tipLength=0.3)
 
 
 def draw_bounding_boxes(event, mouse_x, mouse_y, flags, param):
-    global start_x, start_y, drawing, end_x, end_y, shifting, box_to_shift, changing_shape
-    [drawing_area, boxes] = param
+    global start_x, start_y, drawing, end_x, end_y, shifting, box_to_change, changing_shape
+    [main_drawing_area, secondary_drawing_area, boxes] = param
+    # GREEN --> 'n'     YELLOW --> 'd'
+    color = {'d': (0, 255, 255), 'n': (0, 255, 0)}
+    for boxes_type, boxes_values in all_boxes.items():
+        for box in boxes_values:
+            if box in boxes[boxes_type]:
+                box_main_drawing_area = main_drawing_area
+                box_secondary_drawing_area = secondary_drawing_area
+            else:
+                box_main_drawing_area = secondary_drawing_area
+                box_secondary_drawing_area = main_drawing_area
 
-    for box in boxes:
-        create_bounding_box(drawing_area, box[0], box[1], box[2], box[3])
-        create_cross(drawing_area, box[0], box[1], box[2], box[3])
-        create_plus(drawing_area, box[0], box[1], box[2], box[3])
-        create_change_shape(drawing_area, box[0], box[1], box[2], box[3])
+            create_bounding_box(box_main_drawing_area, box[0], box[1], box[2], box[3], color[boxes_type])
+            create_cross(box_main_drawing_area, box[0], box[1], box[2], box[3])
+            create_plus(box_main_drawing_area, box[0], box[1], box[2], box[3])
+            create_change_shape(box_main_drawing_area, box[0], box[1], box[2], box[3])
+            create_toggle_nd(box_main_drawing_area, box[0], box[1], box[2], box[3])
+            create_bounding_box(box_secondary_drawing_area, box[0], box[1], box[2], box[3], color[boxes_type])
 
     if event == cv2.EVENT_LBUTTONDOWN:
         start_x, start_y = mouse_x, mouse_y
         end_x, end_y = mouse_x, mouse_y
-        for box in boxes:
-            if check_cross_click(start_x, start_y, box):
-                drawing_area[box[1]: box[3] + 1, box[0]: box[2] + 1, 0:3] = 0
-                boxes.remove(box)
-                return
-            if check_plus_click(start_x, start_y, box):
-                drawing_area[box[1]: box[3] + 1, box[0]: box[2] + 1, 0:3] = 0
-                shifting = True
-                box_to_shift = box[:]
-                boxes.remove(box)
-                return
-            if check_arrow_click(start_x, start_y, box):
-                drawing_area[box[1]: box[3] + 1, box[0]: box[2] + 1, 0:3] = 0
-                changing_shape = True
-                box_to_shift = box[:]
-                boxes.remove(box)
-                return
+        for boxes_type, boxes_values in boxes.items():
+            for box in boxes_values:
+                if check_cross_click(start_x, start_y, box):
+                    main_drawing_area[box[1]: box[3] + 1, box[0]: box[2] + 1, 0:3] = 0
+                    secondary_drawing_area[box[1]: box[3] + 1, box[0]: box[2] + 1, 0:3] = 0
+                    boxes_values.remove(box)
+                    return
+                elif check_plus_click(start_x, start_y, box):
+                    main_drawing_area[box[1]: box[3] + 1, box[0]: box[2] + 1, 0:3] = 0
+                    secondary_drawing_area[box[1]: box[3] + 1, box[0]: box[2] + 1, 0:3] = 0
+                    shifting = True
+                    box_to_change['box'] = box[:]
+                    box_to_change['color'] = boxes_type
+                    boxes_values.remove(box)
+                    return
+                elif check_arrow_click(start_x, start_y, box):
+                    main_drawing_area[box[1]: box[3] + 1, box[0]: box[2] + 1, 0:3] = 0
+                    secondary_drawing_area[box[1]: box[3] + 1, box[0]: box[2] + 1, 0:3] = 0
+                    changing_shape = True
+                    box_to_change['box'] = box[:]
+                    box_to_change['color'] = boxes_type
+                    boxes_values.remove(box)
+                    return
+                elif check_toggle_click(start_x, start_y, box):
+                    if box in boxes['n']:
+                        boxes['n'].remove(box)
+                        boxes['d'].append(box)
+                    else:
+                        boxes['d'].remove(box)
+                        boxes['n'].append(box)
+                    return
         drawing = True
     elif event == cv2.EVENT_MOUSEMOVE:
         if drawing is True:
             (box_start_x, box_start_y, box_end_x, box_end_y) = top_left_bottom_right_box(start_x, start_y, end_x, end_y)
-            drawing_area[box_start_y:box_end_y + 1, box_start_x:box_end_x + 1, 0:3] = 0
+            main_drawing_area[box_start_y:box_end_y + 1, box_start_x:box_end_x + 1, 0:3] = 0
+            secondary_drawing_area[box_start_y:box_end_y + 1, box_start_x:box_end_x + 1, 0:3] = 0
             end_x, end_y = mouse_x, mouse_y
-            (box_start_x, box_start_y, box_end_x, box_end_y) = fit_bounding_box(start_x, start_y, end_x, end_y, drawing_area.shape[1], drawing_area.shape[0])
-            create_bounding_box(drawing_area, box_start_x, box_start_y, box_end_x, box_end_y)
+            (box_start_x, box_start_y, box_end_x, box_end_y) = fit_bounding_box(start_x, start_y, end_x, end_y, main_drawing_area.shape[1], main_drawing_area.shape[0])
+            create_bounding_box(main_drawing_area, box_start_x, box_start_y, box_end_x, box_end_y, color['n'])
+            create_bounding_box(secondary_drawing_area, box_start_x, box_start_y, box_end_x, box_end_y, color['n'])
         elif shifting is True:
-            (box_start_x, box_start_y, box_end_x, box_end_y) = shift_bounding_box(box_to_shift, start_x, start_y, end_x, end_y)
-            (box_start_x, box_start_y, box_end_x, box_end_y) = fit_bounding_box(box_start_x, box_start_y, box_end_x, box_end_y, drawing_area.shape[1], drawing_area.shape[0])
-            drawing_area[box_start_y:box_end_y + 1, box_start_x:box_end_x + 1, 0:3] = 0
+            (box_start_x, box_start_y, box_end_x, box_end_y) = shift_bounding_box(box_to_change['box'], start_x, start_y, end_x, end_y)
+            (box_start_x, box_start_y, box_end_x, box_end_y) = fit_bounding_box(box_start_x, box_start_y, box_end_x, box_end_y, main_drawing_area.shape[1], main_drawing_area.shape[0])
+            main_drawing_area[box_start_y:box_end_y + 1, box_start_x:box_end_x + 1, 0:3] = 0
+            secondary_drawing_area[box_start_y:box_end_y + 1, box_start_x:box_end_x + 1, 0:3] = 0
             end_x, end_y = mouse_x, mouse_y
 
-            (box_start_x, box_start_y, box_end_x, box_end_y) = shift_bounding_box(box_to_shift, start_x, start_y, end_x, end_y)
-            (box_start_x, box_start_y, box_end_x, box_end_y) = fit_bounding_box(box_start_x, box_start_y, box_end_x, box_end_y, drawing_area.shape[1], drawing_area.shape[0])
-            create_bounding_box(drawing_area, box_start_x, box_start_y, box_end_x, box_end_y)
+            (box_start_x, box_start_y, box_end_x, box_end_y) = shift_bounding_box(box_to_change['box'], start_x, start_y, end_x, end_y)
+            (box_start_x, box_start_y, box_end_x, box_end_y) = fit_bounding_box(box_start_x, box_start_y, box_end_x, box_end_y, main_drawing_area.shape[1], main_drawing_area.shape[0])
+            create_bounding_box(main_drawing_area, box_start_x, box_start_y, box_end_x, box_end_y, color[box_to_change['color']])
+            create_bounding_box(secondary_drawing_area, box_start_x, box_start_y, box_end_x, box_end_y, color[box_to_change['color']])
         elif changing_shape is True:
-            (box_start_x, box_start_y, box_end_x, box_end_y) = change_bounding_box(box_to_shift, start_x, start_y, end_x, end_y)
-            (box_start_x, box_start_y, box_end_x, box_end_y) = fit_bounding_box(box_start_x, box_start_y, box_end_x, box_end_y, drawing_area.shape[1], drawing_area.shape[0])
-            drawing_area[box_start_y:box_end_y + 1, box_start_x:box_end_x + 1, 0:3] = 0
+            (box_start_x, box_start_y, box_end_x, box_end_y) = change_bounding_box(box_to_change['box'], start_x, start_y, end_x, end_y)
+            (box_start_x, box_start_y, box_end_x, box_end_y) = fit_bounding_box(box_start_x, box_start_y, box_end_x, box_end_y, main_drawing_area.shape[1], main_drawing_area.shape[0])
+            main_drawing_area[box_start_y:box_end_y + 1, box_start_x:box_end_x + 1, 0:3] = 0
+            secondary_drawing_area[box_start_y:box_end_y + 1, box_start_x:box_end_x + 1, 0:3] = 0
             end_x, end_y = mouse_x, mouse_y
-            (box_start_x, box_start_y, box_end_x, box_end_y) = change_bounding_box(box_to_shift, start_x, start_y, end_x, end_y)
-            (box_start_x, box_start_y, box_end_x, box_end_y) = fit_bounding_box(box_start_x, box_start_y, box_end_x, box_end_y, drawing_area.shape[1], drawing_area.shape[0])
-            create_bounding_box(drawing_area, box_start_x, box_start_y, box_end_x, box_end_y)
+            (box_start_x, box_start_y, box_end_x, box_end_y) = change_bounding_box(box_to_change['box'], start_x, start_y, end_x, end_y)
+            (box_start_x, box_start_y, box_end_x, box_end_y) = fit_bounding_box(box_start_x, box_start_y, box_end_x, box_end_y, main_drawing_area.shape[1], main_drawing_area.shape[0])
+            create_bounding_box(main_drawing_area, box_start_x, box_start_y, box_end_x, box_end_y, color[box_to_change['color']])
+            create_bounding_box(secondary_drawing_area, box_start_x, box_start_y, box_end_x, box_end_y, color[box_to_change['color']])
 
     elif event == cv2.EVENT_LBUTTONUP:
         if shifting is True:
             shifting = False
-            (box_start_x, box_start_y, box_end_x, box_end_y) = shift_bounding_box(box_to_shift, start_x, start_y, end_x, end_y)
-            (box_start_x, box_start_y, box_end_x, box_end_y) = fit_bounding_box(box_start_x, box_start_y, box_end_x, box_end_y, drawing_area.shape[1], drawing_area.shape[0])
-            boxes.append([box_start_x, box_start_y, box_end_x, box_end_y])
+            (box_start_x, box_start_y, box_end_x, box_end_y) = shift_bounding_box(box_to_change['box'], start_x, start_y, end_x, end_y)
+            (box_start_x, box_start_y, box_end_x, box_end_y) = fit_bounding_box(box_start_x, box_start_y, box_end_x, box_end_y, main_drawing_area.shape[1], main_drawing_area.shape[0])
+            boxes[box_to_change['color']].append([box_start_x, box_start_y, box_end_x, box_end_y])
         elif drawing is True:
             drawing = False
             (start_x, start_y, end_x, end_y) = top_left_bottom_right_box(start_x, start_y, end_x, end_y)
-            (box_start_x, box_start_y, box_end_x, box_end_y) = fit_bounding_box(start_x, start_y, end_x, end_y, drawing_area.shape[1], drawing_area.shape[0])
-            boxes.append([box_start_x, box_start_y, box_end_x, box_end_y])
+            (box_start_x, box_start_y, box_end_x, box_end_y) = fit_bounding_box(start_x, start_y, end_x, end_y, main_drawing_area.shape[1], main_drawing_area.shape[0])
+            boxes['n'].append([box_start_x, box_start_y, box_end_x, box_end_y])
         elif changing_shape is True:
             changing_shape = False
-            (box_start_x, box_start_y, box_end_x, box_end_y) = change_bounding_box(box_to_shift, start_x, start_y, end_x, end_y)
-            (box_start_x, box_start_y, box_end_x, box_end_y) = fit_bounding_box(box_start_x, box_start_y, box_end_x, box_end_y, drawing_area.shape[1], drawing_area.shape[0])
-            boxes.append([box_start_x, box_start_y, box_end_x, box_end_y])
+            (box_start_x, box_start_y, box_end_x, box_end_y) = change_bounding_box(box_to_change['box'], start_x, start_y, end_x, end_y)
+            (box_start_x, box_start_y, box_end_x, box_end_y) = fit_bounding_box(box_start_x, box_start_y, box_end_x, box_end_y, main_drawing_area.shape[1], main_drawing_area.shape[0])
+            boxes[box_to_change['color']].append([box_start_x, box_start_y, box_end_x, box_end_y])
 
 
 # The images are not the same and you want to mark the bounding box.
 def get_new_image():
+    global all_boxes
     current_image = images_to_show.pop()
     print("Reading %s" % current_image)
     firefox_screenshot = cv2.imread("data/%s_firefox.png" % current_image)
@@ -186,11 +230,14 @@ def get_new_image():
         return 0
     drawing_area_firefox = reset_bounding_boxes(firefox_screenshot.shape)
     drawing_area_chrome = reset_bounding_boxes(chrome_screenshot.shape)
-    boxes_firefox, boxes_chrome = [], []
-    cv2.setMouseCallback('firefox', draw_bounding_boxes, [drawing_area_firefox, boxes_firefox])
-    cv2.setMouseCallback('chrome', draw_bounding_boxes, [drawing_area_chrome, boxes_chrome])
+    all_boxes, boxes_firefox, boxes_chrome = {'n': [], 'd': []}, {'n': [], 'd': []}, {'n': [], 'd': []}
+
+    cv2.setMouseCallback('firefox', draw_bounding_boxes, [drawing_area_firefox, drawing_area_chrome, boxes_firefox])
+    cv2.setMouseCallback('chrome', draw_bounding_boxes, [drawing_area_chrome, drawing_area_firefox, boxes_chrome])
     visibility = 1
     while True:
+        all_boxes['n'] = boxes_firefox['n'][:] + boxes_chrome['n'][:]
+        all_boxes['d'] = boxes_firefox['d'][:] + boxes_chrome['d'][:]
         firefox_window = cv2.addWeighted(drawing_area_firefox, 1 - visibility, firefox_screenshot, visibility, 0)
         chrome_window = cv2.addWeighted(drawing_area_chrome, 1 - visibility, chrome_screenshot, visibility, 0)
         firefox_chrome_overlay = cv2.addWeighted(firefox_screenshot, 0.5, chrome_screenshot, 0.5, 0)
@@ -209,33 +256,38 @@ def get_new_image():
         elif k == key_map["r"]:
             drawing_area_firefox = reset_bounding_boxes(firefox_screenshot.shape)
             drawing_area_chrome = reset_bounding_boxes(chrome_screenshot.shape)
-            boxes_chrome, boxes_firefox = [], []
-            cv2.setMouseCallback('firefox', draw_bounding_boxes, [drawing_area_firefox, boxes_firefox])
-            cv2.setMouseCallback('chrome', draw_bounding_boxes, [drawing_area_chrome, boxes_chrome])
+            all_boxes, boxes_chrome, boxes_firefox = [], [], []
+            cv2.setMouseCallback('firefox', draw_bounding_boxes, [drawing_area_firefox, drawing_area_chrome, boxes_firefox])
+            cv2.setMouseCallback('chrome', draw_bounding_boxes, [drawing_area_chrome, drawing_area_firefox, boxes_chrome])
         # <Return> saves the current marking and moves to next image
         elif k == key_map["Enter"]:
-            bounding_boxes[current_image + '_firefox'] = boxes_firefox
-            bounding_boxes[current_image + '_chrome'] = boxes_chrome
-            return 0
+            if visibility == 1:
+                visibility = 0.5
+            else:
+                bounding_boxes[current_image + '_firefox'] = boxes_firefox
+                bounding_boxes[current_image + '_chrome'] = boxes_chrome
+                if len(boxes_chrome['n'] + boxes_firefox['n']) == 0:
+                    labels[current_image] = 'd'
+                elif len(boxes_chrome['n'] + boxes_firefox['n'] + boxes_chrome['d'] + boxes_firefox['d']) == 0:
+                    labels[current_image] = 'y'
+                else:
+                    labels[current_image] = 'n'
+                return 0
         # <Space> skips the labeling of current image
         elif k == key_map["Space"]:
-            if current_image not in labels.keys():
-                return 0
+            return 0
         elif k == key_map["y"]:
+            bounding_boxes[current_image + '_firefox'] = boxes_firefox
+            bounding_boxes[current_image + '_chrome'] = boxes_chrome
             labels[current_image] = 'y'
             return 0
-        elif k == key_map["n"]:
-            labels[current_image] = 'n'
-            visibility = 0.5
-        elif k == key_map["d"]:
-            labels[current_image] = 'd'
-            visibility = 0.5
 
 
 def main():
     while len(images_to_show):
         if get_new_image():
             break
+
     # Store results.
     utils.write_bounding_boxes(bounding_boxes, labels_directory + args.file_name + "_bounding_box.json")
     utils.write_labels(labels, labels_directory + args.file_name + ".csv")

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ selenium==3.4.3
 keras==2.1.1
 tensorflow==1.3.0
 h5py==2.7.1
+opencv-python==3.4.0.12 


### PR DESCRIPTION
Solves #118

How it works?
- Keypress of ```'n', 'y', ' d'``` works same as they worked previously.
- Press ```'m' ``` to mark the images as ```not compatible``` (ie same as what pressing ```n``` does) and enter into selection region.
- Select different boundary boxes (you can select more than one) in both images.
- If you make a mistake press ```'r'``` to reset all boundary boxes.
- Press ```Escape``` to exit selection region without saving your ```boundary_boxes```
- Press ```Return``` to save your ```boundary_boxes``` into a file in directory ```label_persons``` named as ```filename_boundary_box.csv```
- Data in ```filename_boundary_box.csv``` is stored in format ```filename,list _of_boundary_boxes```