### PR TITLE
Removing one maxpooling layer in vgg16 architecture

### DIFF
--- a/autowebcompat/network.py
+++ b/autowebcompat/network.py
@@ -39,7 +39,7 @@ def create_vgg16_network(input_shape):
     # Block 2
     x = Conv2D(128, (3, 3), activation='relu', padding='same')(x)
     x = Conv2D(128, (3, 3), activation='relu', padding='same',)(x)
-    x = MaxPooling2D(pool_size=(2, 2), strides=(2, 2))(x)
+    # x = MaxPooling2D(pool_size=(2, 2), strides=(2, 2))(x)
 
     # Block 3
     x = Conv2D(256, (3, 3), activation='relu', padding='same')(x)


### PR DESCRIPTION
Since our input size is 32x24x3
so in vgg16 input dimension is reduced to  -negative dimension (invalid) due to strides in the last max-pooling layer, so one max-pooling layer must be removed.
    # Block 1 output  size  16x12x64
    # Block 2 output  size  8x4x128
    # Block 3 output  size  4x2x256
    # Block 4 output  size  2x1x512
    # Block 5 output size  1x-1x512 (invalid)
getting this error 
ValueError: Negative dimension size caused by subtracting 2 from 1 for 'max_pooling2d_5/MaxPool' (op: 'MaxPool') with input shapes: [?,2,1,512].
