### PR TITLE
Add confusion matrix for test iterator.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ selenium==3.4.3
 keras==2.1.1
 tensorflow==1.3.0
 h5py==2.7.1
-opencv-python==3.4.0.12 
+opencv-python==3.4.0.12
+scikit-learn==0.19.1 

--- a/train.py
+++ b/train.py
@@ -5,6 +5,8 @@ import time
 from keras.callbacks import Callback
 from keras.callbacks import EarlyStopping
 from keras.callbacks import ModelCheckpoint
+import numpy as np
+from sklearn.metrics import confusion_matrix
 
 from autowebcompat import network
 from autowebcompat import utils
@@ -89,6 +91,18 @@ if args.early_stopping:
 train_history = model.fit_generator(train_iterator, callbacks=callbacks_list, validation_data=validation_iterator, steps_per_epoch=train_couples_len / BATCH_SIZE, validation_steps=validation_couples_len / BATCH_SIZE, epochs=EPOCHS)
 score = model.evaluate_generator(test_iterator, steps=test_couples_len / BATCH_SIZE)
 print(score)
+
+y_true, y_pred = [], []
+for i, (x, y) in enumerate(test_iterator):
+    y_pred_batch = model.predict_on_batch(x)
+    y_pred_batch = np.where(y_pred_batch > 0.5, 1, 0)
+    y_true.extend(y)
+    y_pred.extend(y_pred_batch.flatten().tolist())
+    if i == test_couples_len // BATCH_SIZE:
+        break
+
+print('Confusion Matrix')
+print(confusion_matrix(y_true, y_pred))
 
 train_history = train_history.history
 train_history.update({'epoch time': timer.epoch_times})

--- a/train.py
+++ b/train.py
@@ -95,7 +95,7 @@ print(score)
 y_true, y_pred = [], []
 for i, (x, y) in enumerate(test_iterator):
     y_pred_batch = model.predict_on_batch(x)
-    y_pred_batch = np.where(y_pred_batch > 0.5, 1, 0)
+    y_pred_batch = np.where(y_pred_batch < 0.5, 1, 0)
     y_true.extend(y)
     y_pred.extend(y_pred_batch.flatten().tolist())
     if i == test_couples_len // BATCH_SIZE:


### PR DESCRIPTION
I tried directly using the `predict_generator` available in `keras` to get the predicted values. I was not able to get the `true values` from it. I tried adding an accumulator in `CouplesIterator` class and append `y_batch` to it, but `next` function was being called 23 times which should have been 12 times (using `steps=test_couples_len / BATCH_SIZE`) `test_couples_len = 396`