### PR TITLE
Add handling for edge cases where file may not exist or be empty

### DIFF
--- a/autowebcompat/utils.py
+++ b/autowebcompat/utils.py
@@ -188,13 +188,16 @@ def make_infinite(gen_func, elems):
 
 
 def read_labels(file_name='labels.csv'):
-    try:
-        with open(file_name, 'r', newline='') as f:
-            next(f)
-            reader = csv.reader(f)
-            labels = {row[0]: row[1] for row in reader}
-    except FileNotFoundError:
+    if os.stat(file_name).st_size == 0:
         labels = {}
+    else:
+        try:
+            with open(file_name, 'r', newline='') as f:
+                next(f)
+                reader = csv.reader(f)
+                labels = {row[0]: row[1] for row in reader}
+        except FileNotFoundError:
+            labels = {}
     return labels
 
 


### PR DESCRIPTION
This is a fix for #261 accounting for blank files with `os.stat()` and preventing errors from being thrown.