### PR TITLE
Remove image caching from utils.load_image

### DIFF
--- a/autowebcompat/utils.py
+++ b/autowebcompat/utils.py
@@ -81,17 +81,8 @@ images = {}
 
 
 def load_image(fname, parent_dir='data_resized'):
-    global images
-
-    if fname in images:
-        return images[fname]
-
-    img = load_img(os.path.join(parent_dir, fname), target_size=(32, 24))
-    x = img_to_array(img, data_format=keras.backend.image_data_format())
-
-    images[fname] = x
-
-    return x
+    img = load_img(os.path.join(parent_dir, fname), target_size=(224, 224))
+    return img_to_array(img, data_format=keras.backend.image_data_format())
 
 
 def get_ImageDataGenerator(images, image_shape, parent_dir='data_resized'):


### PR DESCRIPTION
Caching all the images like this will eventually lead to OOM. Let's just
read and resize them from disk every time we need them.