### PR TITLE
Fix for OOM issue while running in Colab

### DIFF
--- a/autowebcompat/utils.py
+++ b/autowebcompat/utils.py
@@ -81,20 +81,12 @@ images = {}
 
 
 def load_image(fname, parent_dir='data_resized'):
-    img = load_img(os.path.join(parent_dir, fname), target_size=(32, 24))
+    img = load_img(os.path.join(parent_dir, fname), target_size=(224, 224))
     return img_to_array(img, data_format=keras.backend.image_data_format())
 
 
 def get_ImageDataGenerator(images, image_shape, parent_dir='data_resized'):
     data_gen = ImageDataGenerator(rescale=1. / 255)
-
-    x = np.zeros((len(images),) + image_shape, dtype=keras.backend.floatx())
-
-    for i, image in enumerate(images):
-        x[i] = load_image(image, parent_dir)
-
-    data_gen.fit(x)
-
     return data_gen
 
 

--- a/autowebcompat/utils.py
+++ b/autowebcompat/utils.py
@@ -81,7 +81,7 @@ images = {}
 
 
 def load_image(fname, parent_dir='data_resized'):
-    img = load_img(os.path.join(parent_dir, fname), target_size=(224, 224))
+    img = load_img(os.path.join(parent_dir, fname), target_size=(32, 24))
     return img_to_array(img, data_format=keras.backend.image_data_format())
 
 


### PR DESCRIPTION
Fixes #280 
The problem was fixed by removing the creation of an array containing a vector for every image file in utils.py/get_ImageDataGenerator. The code was there in preparation for a call to fit() for the ImageGenerator object. Upon inspecting the documentation for this method, it turns out that this call was not necessary for the image processing we are doing.

I tested this on Colab for a few epochs on vgg16 using imagenet weights.
